### PR TITLE
Add optional low-footprint printf float replacement

### DIFF
--- a/src/ts_config.h
+++ b/src/ts_config.h
@@ -36,4 +36,20 @@
 #define TS_64BIT_TYPES_SUPPORT 0        // default: no support
 #endif
 
+/*
+ * Specify if the used lib-c implementation supports printing floats
+ *
+ * If float is not supported, a low-footprint custom implementation will be used for JSON output.
+ *
+ * Important: The custom implementation is not guaranteed to produce correct results under all
+ * circumstances (e.g. very large or small numbers). If unsure, enable lib-c float support!
+ */
+#ifndef TS_PRINTF_FLOAT_SUPPORT
+#ifdef CONFIG_NEWLIB_LIBC_FLOAT_PRINTF
+#define TS_PRINTF_FLOAT_SUPPORT 1       // float support provided by Zephyr
+#else
+#define TS_PRINTF_FLOAT_SUPPORT 0       // use custom implementation
+#endif
+#endif
+
 #endif /* __TS_CONFIG_H_ */

--- a/test/tests_txt.cpp
+++ b/test/tests_txt.cpp
@@ -56,10 +56,43 @@ void test_txt_fetch_array()
 
 void test_txt_fetch_rounded()
 {
-    size_t req_len = snprintf((char *)req_buf, TS_REQ_BUFFER_LEN, "?conf \"f32_rounded\"");
+    f32 = -52.005;
+
+    size_t req_len = snprintf((char *)req_buf, TS_REQ_BUFFER_LEN, "?conf \"f32\"");
     int resp_len = ts.process(req_buf, req_len, resp_buf, TS_RESP_BUFFER_LEN);
     TEST_ASSERT_EQUAL(strlen((char *)resp_buf), resp_len);
+    TEST_ASSERT_EQUAL_STRING(":85 Content. -52.01", resp_buf);
+
+    f32 = 52.80;
+
+    req_len = snprintf((char *)req_buf, TS_REQ_BUFFER_LEN, "?conf \"f32_rounded\"");
+    resp_len = ts.process(req_buf, req_len, resp_buf, TS_RESP_BUFFER_LEN);
+    TEST_ASSERT_EQUAL(strlen((char *)resp_buf), resp_len);
     TEST_ASSERT_EQUAL_STRING(":85 Content. 53", resp_buf);
+}
+
+void test_txt_fetch_nan()
+{
+    int nan = 0x7F800001;
+    f32 = *(float*)&nan;
+
+    TEST_ASSERT(isnan(f32));
+
+    size_t req_len = snprintf((char *)req_buf, TS_REQ_BUFFER_LEN, "?conf \"f32\"");
+    int resp_len = ts.process(req_buf, req_len, resp_buf, TS_RESP_BUFFER_LEN);
+    TEST_ASSERT_EQUAL(strlen((char *)resp_buf), resp_len);
+    TEST_ASSERT_EQUAL_STRING(":85 Content. null", resp_buf);
+}
+
+void test_txt_fetch_inf()
+{
+    int inf = 0x7F800000;
+    f32 = *(float*)&inf;
+
+    size_t req_len = snprintf((char *)req_buf, TS_REQ_BUFFER_LEN, "?conf \"f32\"");
+    int resp_len = ts.process(req_buf, req_len, resp_buf, TS_RESP_BUFFER_LEN);
+    TEST_ASSERT_EQUAL(strlen((char *)resp_buf), resp_len);
+    TEST_ASSERT_EQUAL_STRING(":85 Content. null", resp_buf);
 }
 
 void test_txt_fetch_int32_array()
@@ -350,6 +383,8 @@ void tests_text_mode()
     // FETCH request
     RUN_TEST(test_txt_fetch_array);
     RUN_TEST(test_txt_fetch_rounded);
+    RUN_TEST(test_txt_fetch_nan);
+    RUN_TEST(test_txt_fetch_inf);
     RUN_TEST(test_txt_fetch_int32_array);
     RUN_TEST(test_txt_fetch_float_array);
 


### PR DESCRIPTION
Disabling float support in the firmware via Kconfig and using this replacement instead saved about 4.5 kB of flash during my tests.

Please double-check if the approach makes sense and if I may have missed any important edge cases.