### PR TITLE
Updates for ThingSet Protocol draft v0.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ build_flags =
     -D TS_64BIT_TYPES_SUPPORT=1
     -D TS_DECFRAC_TYPE_SUPPORT=1
     -D TS_BYTE_STRING_TYPE_SUPPORT=1
+    -D TS_NESTED_JSON=1
 
 # include src directory (otherwise unit-tests will only include lib directory)
 test_build_project_src = true

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -70,22 +70,6 @@ void ts_set_authentication(struct ts_context *ts, uint8_t flags)
     ts->_auth_flags = flags;
 }
 
-bool ts_check_updated(struct ts_context *ts, const uint16_t subsets, bool clear)
-{
-    bool updated = false;
-
-    for (unsigned int i = 0; i < ts->num_objects; i++) {
-        if (ts->data_objects[i].updated == 1U && (ts->data_objects[i].subsets & subsets)) {
-            updated = true;
-            if (clear) {
-                ts->data_objects[i].updated = 0U;
-            }
-        }
-    }
-
-    return updated;
-}
-
 struct ts_data_object *ts_get_object_by_name(struct ts_context *ts, const char *name,
                                              size_t len, int32_t parent)
 {

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -65,7 +65,7 @@ int ts_process(struct ts_context *ts, const uint8_t *request, size_t request_len
     }
 }
 
-void ts_set_authentication(struct ts_context *ts, uint16_t flags)
+void ts_set_authentication(struct ts_context *ts, uint8_t flags)
 {
     ts->_auth_flags = flags;
 }

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -70,6 +70,12 @@ void ts_set_authentication(struct ts_context *ts, uint8_t flags)
     ts->_auth_flags = flags;
 }
 
+void ts_set_update_callback(struct ts_context *ts, const uint16_t subsets, void (*update_cb)(void))
+{
+    ts->_update_subsets = subsets;
+    ts->update_cb = update_cb;
+}
+
 struct ts_data_object *ts_get_object_by_name(struct ts_context *ts, const char *name,
                                              size_t len, int32_t parent)
 {

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -70,6 +70,22 @@ void ts_set_authentication(struct ts_context *ts, uint8_t flags)
     ts->_auth_flags = flags;
 }
 
+bool ts_check_updated(struct ts_context *ts, const uint16_t subsets, bool clear)
+{
+    bool updated = false;
+
+    for (unsigned int i = 0; i < ts->num_objects; i++) {
+        if (ts->data_objects[i].updated == 1U && (ts->data_objects[i].subsets & subsets)) {
+            updated = true;
+            if (clear) {
+                ts->data_objects[i].updated = 0U;
+            }
+        }
+    }
+
+    return updated;
+}
+
 struct ts_data_object *ts_get_object_by_name(struct ts_context *ts, const char *name,
                                              size_t len, int32_t parent)
 {

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -404,9 +404,15 @@ struct ts_data_object {
     const uint32_t type : 4;
 
     /**
-     * Exponent (10^exponent = factor to convert to SI unit) for decimal fraction type,
-     * decimal digits to use for printing of floats in JSON strings or
-     * length of string buffer for string type
+     * Variable storing different detail information depending on th data type
+     *
+     * - FLOAT32: Decimal digits (precision) to use for printing in JSON strings.
+     *
+     * - DECFRAC: Exponent (10^exponent = factor to convert to internal unit). Example: If
+     *   a voltage measurement is internally stored as an integer in mV, use exponent -3 to
+     *   convert to the SI base unit V as exposed via ThingSet.
+     *
+     * - STRING or BYTES: Size of the internal buffer in bytes.
      */
     const int32_t detail : 12;
 

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -480,6 +480,17 @@ struct ts_context {
      * Stores current authentication status (authentication as "normal" user as default)
      */
     uint8_t _auth_flags;
+
+    /**
+     * Stores current authentication status (authentication as "normal" user as default)
+     */
+    uint8_t _update_subsets;
+
+    /**
+     * Callback to be called from patch function if a value belonging to _update_subsets
+     * was changed
+     */
+    void (*update_cb)(void);
 };
 
 /**
@@ -530,6 +541,15 @@ void ts_dump_json(struct ts_context *ts, ts_object_id_t obj_id, int level);
  * @param flags Flags to define authentication level (1 = access allowed)
  */
 void ts_set_authentication(struct ts_context *ts, uint8_t flags);
+
+/**
+ * Configures a callback for notification if data belonging to specified subset(s) was updated.
+ *
+ * @param ts Pointer to ThingSet context.
+ * @param subsets Flags to select which subset(s) of data items should be considered
+ * @param update_cb Callback to be called after an update.
+ */
+void ts_set_update_callback(struct ts_context *ts, const uint16_t subsets, void (*update_cb)(void));
 
 /**
  * Retrieve data in JSON format for given subset(s).
@@ -763,6 +783,11 @@ public:
     inline void set_authentication(uint8_t flags)
     {
         ts_set_authentication(&ts, flags);
+    };
+
+    inline void set_update_callback(const uint16_t subsets, void (*update_cb)(void))
+    {
+        ts_set_update_callback(&ts, subsets, update_cb);
     };
 
     inline int txt_export(char *buf, size_t size, const uint16_t subsets)

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -418,12 +418,8 @@ struct ts_data_object {
     /**
      * Flags to assign data item to different data item subsets (e.g. for publication messages)
      */
-    uint32_t subsets : 7;
+    uint32_t subsets : 8;
 
-    /**
-     * Bit to store if value has been updated via ThingSet (e.g. for NVM stoarage)
-     */
-    uint32_t updated : 1;
 };
 
 /* support for legacy code with old nomenclature */
@@ -534,15 +530,6 @@ void ts_dump_json(struct ts_context *ts, ts_object_id_t obj_id, int level);
  * @param flags Flags to define authentication level (1 = access allowed)
  */
 void ts_set_authentication(struct ts_context *ts, uint8_t flags);
-
-/**
- * Checks if any of the data objects belonging to the subsets was updated.
- *
- * @param ts Pointer to ThingSet context.
- * @param subsets Flags to select which subset(s) of data items should be considered
- * @param clear If set to true, the updated status is cleared after checking.
- */
-bool ts_check_updated(struct ts_context *ts, const uint16_t subsets, bool clear);
 
 /**
  * Retrieve data in JSON format for given subset(s).
@@ -776,11 +763,6 @@ public:
     inline void set_authentication(uint8_t flags)
     {
         ts_set_authentication(&ts, flags);
-    };
-
-    inline bool check_updated(const uint16_t subsets, bool clear)
-    {
-        return ts_check_updated(&ts, subsets, clear);
     };
 
     inline int txt_export(char *buf, size_t size, const uint16_t subsets)

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -418,8 +418,12 @@ struct ts_data_object {
     /**
      * Flags to assign data item to different data item subsets (e.g. for publication messages)
      */
-    uint32_t subsets : 8;
+    uint32_t subsets : 7;
 
+    /**
+     * Bit to store if value has been updated via ThingSet (e.g. for NVM stoarage)
+     */
+    uint32_t updated : 1;
 };
 
 /* support for legacy code with old nomenclature */
@@ -530,6 +534,15 @@ void ts_dump_json(struct ts_context *ts, ts_object_id_t obj_id, int level);
  * @param flags Flags to define authentication level (1 = access allowed)
  */
 void ts_set_authentication(struct ts_context *ts, uint8_t flags);
+
+/**
+ * Checks if any of the data objects belonging to the subsets was updated.
+ *
+ * @param ts Pointer to ThingSet context.
+ * @param subsets Flags to select which subset(s) of data items should be considered
+ * @param clear If set to true, the updated status is cleared after checking.
+ */
+bool ts_check_updated(struct ts_context *ts, const uint16_t subsets, bool clear);
 
 /**
  * Retrieve data in JSON format for given subset(s).
@@ -763,6 +776,11 @@ public:
     inline void set_authentication(uint8_t flags)
     {
         ts_set_authentication(&ts, flags);
+    };
+
+    inline bool check_updated(const uint16_t subsets, bool clear)
+    {
+        return ts_check_updated(&ts, subsets, clear);
     };
 
     inline int txt_export(char *buf, size_t size, const uint16_t subsets)

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -341,15 +341,15 @@ static inline void *ts_array_to_void(struct ts_array_info *ptr) { return (void *
 #define TS_ROLE_EXP     (1U << 1)       // expert user
 #define TS_ROLE_MKR     (1U << 2)       // maker
 
-#define TS_READ_MASK    0x00FF          // read flags stored in 4 least-significant bits
-#define TS_WRITE_MASK   0xFF00          // write flags stored in 4 most-significant bits
+#define TS_READ_MASK    0x0F          // read flags stored in 4 least-significant bits
+#define TS_WRITE_MASK   0xF0          // write flags stored in 4 most-significant bits
 
-#define TS_USR_MASK     (TS_ROLE_USR << 8 | TS_ROLE_USR)
-#define TS_EXP_MASK     (TS_ROLE_EXP << 8 | TS_ROLE_EXP)
-#define TS_MKR_MASK     (TS_ROLE_MKR << 8 | TS_ROLE_MKR)
+#define TS_USR_MASK     (TS_ROLE_USR << 4 | TS_ROLE_USR)
+#define TS_EXP_MASK     (TS_ROLE_EXP << 4 | TS_ROLE_EXP)
+#define TS_MKR_MASK     (TS_ROLE_MKR << 4 | TS_ROLE_MKR)
 
 #define TS_READ(roles)          ((roles) & TS_READ_MASK)
-#define TS_WRITE(roles)         (((roles) << 8) & TS_WRITE_MASK)
+#define TS_WRITE(roles)         (((roles) << 4) & TS_WRITE_MASK)
 #define TS_READ_WRITE(roles)    (TS_READ(roles) | TS_WRITE(roles))
 
 #define TS_USR_R        TS_READ(TS_ROLE_USR)
@@ -401,24 +401,24 @@ struct ts_data_object {
     /**
      * One of TS_TYPE_INT32, _FLOAT, ...
      */
-    const uint8_t type;
+    const uint32_t type : 4;
 
     /**
      * Exponent (10^exponent = factor to convert to SI unit) for decimal fraction type,
      * decimal digits to use for printing of floats in JSON strings or
      * length of string buffer for string type
      */
-    const int16_t detail;
+    const int32_t detail : 12;
 
     /**
      * Flags to define read/write access
      */
-    const uint16_t access;
+    const uint32_t access : 8;
 
     /**
      * Flags to assign data item to different data item subsets (e.g. for publication messages)
      */
-    uint16_t subsets;
+    uint32_t subsets : 8;
 
 };
 
@@ -479,7 +479,7 @@ struct ts_context {
     /**
      * Stores current authentication status (authentication as "normal" user as default)
      */
-    uint16_t _auth_flags;
+    uint8_t _auth_flags;
 };
 
 /**
@@ -529,7 +529,7 @@ void ts_dump_json(struct ts_context *ts, ts_object_id_t obj_id, int level);
  * @param ts Pointer to ThingSet context.
  * @param flags Flags to define authentication level (1 = access allowed)
  */
-void ts_set_authentication(struct ts_context *ts, uint16_t flags);
+void ts_set_authentication(struct ts_context *ts, uint8_t flags);
 
 /**
  * Retrieve data in JSON format for given subset(s).
@@ -676,7 +676,7 @@ int ts_bin_pub_can(struct ts_context *ts, int *start_pos, uint16_t subset, uint8
  *
  * @returns ThingSet status code
  */
-int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint16_t auth_flags,
+int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint8_t auth_flags,
                   uint16_t subsets);
 
 /**
@@ -760,7 +760,7 @@ public:
         ts_dump_json(&ts, obj_id, level);
     };
 
-    inline void set_authentication(uint16_t flags)
+    inline void set_authentication(uint8_t flags)
     {
         ts_set_authentication(&ts, flags);
     };
@@ -790,7 +790,7 @@ public:
         return ts_bin_export(&ts, buf, size, subsets);
     };
 
-    inline int bin_import(uint8_t *buf, size_t size, uint16_t auth_flags, const uint16_t subsets)
+    inline int bin_import(uint8_t *buf, size_t size, uint8_t auth_flags, const uint16_t subsets)
     {
         return ts_bin_import(&ts, buf, size, auth_flags, subsets);
     };
@@ -880,7 +880,7 @@ public:
      *
      * @returns ThingSet status code
      */
-    inline int bin_sub(uint8_t *cbor_data, size_t len, uint16_t auth_flags, uint16_t subsets)
+    inline int bin_sub(uint8_t *cbor_data, size_t len, uint8_t auth_flags, uint16_t subsets)
         __attribute__((deprecated))
     {
         return ts_bin_import(&ts, cbor_data + 1, len - 1, auth_flags, subsets);

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -20,8 +20,10 @@ static int cbor_serialize_array_type(uint8_t *buf, size_t size,
                                      const struct ts_data_object *data_obj);
 
 
-static int cbor_deserialize_data_obj(const uint8_t *buf, const struct ts_data_object *data_obj)
+static int cbor_deserialize_data_obj(const uint8_t *buf, struct ts_data_object *data_obj)
 {
+    data_obj->updated = 1;
+
     switch (data_obj->type) {
 #if TS_64BIT_TYPES_SUPPORT
     case TS_T_UINT64:
@@ -383,7 +385,7 @@ int ts_bin_patch(struct ts_context *ts, const struct ts_data_object *parent,
         }
         pos_req += num_bytes;
 
-        const struct ts_data_object* object = ts_get_object_by_id(ts, id);
+        struct ts_data_object* object = ts_get_object_by_id(ts, id);
         if (object) {
             if ((object->access & TS_WRITE_MASK & auth_flags) == 0) {
                 if (object->access & TS_WRITE_MASK) {

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -345,7 +345,7 @@ int ts_bin_fetch(struct ts_context *ts, const struct ts_data_object *parent, uin
     }
 }
 
-int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint16_t auth_flags,
+int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint8_t auth_flags,
                   uint16_t subsets)
 {
     uint8_t resp_tmp[1] = {};   // only one character as response expected
@@ -358,7 +358,7 @@ int ts_bin_import(struct ts_context *ts, uint8_t *data, size_t len, uint16_t aut
 }
 
 int ts_bin_patch(struct ts_context *ts, const struct ts_data_object *parent,
-                 unsigned int pos_payload, uint16_t auth_flags, uint16_t subsets)
+                 unsigned int pos_payload, uint8_t auth_flags, uint16_t subsets)
 {
     unsigned int pos_req = pos_payload;
     uint16_t num_elements, element = 0;

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -20,10 +20,8 @@ static int cbor_serialize_array_type(uint8_t *buf, size_t size,
                                      const struct ts_data_object *data_obj);
 
 
-static int cbor_deserialize_data_obj(const uint8_t *buf, struct ts_data_object *data_obj)
+static int cbor_deserialize_data_obj(const uint8_t *buf, const struct ts_data_object *data_obj)
 {
-    data_obj->updated = 1;
-
     switch (data_obj->type) {
 #if TS_64BIT_TYPES_SUPPORT
     case TS_T_UINT64:
@@ -385,7 +383,7 @@ int ts_bin_patch(struct ts_context *ts, const struct ts_data_object *parent,
         }
         pos_req += num_bytes;
 
-        struct ts_data_object* object = ts_get_object_by_id(ts, id);
+        const struct ts_data_object* object = ts_get_object_by_id(ts, id);
         if (object) {
             if ((object->access & TS_WRITE_MASK & auth_flags) == 0) {
                 if (object->access & TS_WRITE_MASK) {

--- a/src/thingset_priv.h
+++ b/src/thingset_priv.h
@@ -200,7 +200,7 @@ int ts_json_serialize_name_value(struct ts_context *ts, char *buf, size_t size,
  * @returns Number of tokens processed (always 1) or 0 in case of error
  */
 int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmntype_t type,
-                              const struct ts_data_object *object);
+                              struct ts_data_object *object);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/thingset_priv.h
+++ b/src/thingset_priv.h
@@ -114,7 +114,7 @@ int ts_txt_patch(struct ts_context *ts,  const struct ts_data_object *parent);
  * @param subsets Bitset to specifiy data item subsets to be considered, 0 to ignore
  */
 int ts_bin_patch(struct ts_context *ts, const struct ts_data_object *parent,
-                 unsigned int pos_payload, uint16_t auth_flags, uint16_t subsets);
+                 unsigned int pos_payload, uint8_t auth_flags, uint16_t subsets);
 
 /**
  * POST request to append data.

--- a/src/thingset_priv.h
+++ b/src/thingset_priv.h
@@ -200,7 +200,7 @@ int ts_json_serialize_name_value(struct ts_context *ts, char *buf, size_t size,
  * @returns Number of tokens processed (always 1) or 0 in case of error
  */
 int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmntype_t type,
-                              struct ts_data_object *object);
+                              const struct ts_data_object *object);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/thingset_txt.c
+++ b/src/thingset_txt.c
@@ -423,7 +423,7 @@ int ts_txt_fetch(struct ts_context *ts, const struct ts_data_object *parent)
 }
 
 int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmntype_t type,
-                              const struct ts_data_object *object)
+                              struct ts_data_object *object)
 {
 #if TS_DECFRAC_TYPE_SUPPORT
     float tmp;
@@ -496,6 +496,8 @@ int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmn
         return 0;
     }
 
+    object->updated = 1;
+
     return 1;   // value always contained in one token (arrays not yet supported)
 }
 
@@ -529,7 +531,7 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
             return ts_txt_response(ts, TS_STATUS_BAD_REQUEST);
         }
 
-        const struct ts_data_object* object = ts_get_object_by_name(ts,
+        struct ts_data_object* object = ts_get_object_by_name(ts,
             ts->json_str + ts->tokens[tok].start,
             ts->tokens[tok].end - ts->tokens[tok].start, parent_id);
 
@@ -583,7 +585,7 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
     // actually write data
     while (tok + 1 < ts->tok_count) {
 
-        const struct ts_data_object *object =
+        struct ts_data_object *object =
             ts_get_object_by_name(ts, ts->json_str + ts->tokens[tok].start,
                 ts->tokens[tok].end - ts->tokens[tok].start, parent_id);
 

--- a/src/thingset_txt.c
+++ b/src/thingset_txt.c
@@ -437,7 +437,7 @@ int ts_txt_fetch(struct ts_context *ts, const struct ts_data_object *parent)
 }
 
 int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmntype_t type,
-                              struct ts_data_object *object)
+                              const struct ts_data_object *object)
 {
 #if TS_DECFRAC_TYPE_SUPPORT
     float tmp;
@@ -510,8 +510,6 @@ int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmn
         return 0;
     }
 
-    object->updated = 1;
-
     return 1;   // value always contained in one token (arrays not yet supported)
 }
 
@@ -545,7 +543,7 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
             return ts_txt_response(ts, TS_STATUS_BAD_REQUEST);
         }
 
-        struct ts_data_object* object = ts_get_object_by_name(ts,
+        const struct ts_data_object* object = ts_get_object_by_name(ts,
             ts->json_str + ts->tokens[tok].start,
             ts->tokens[tok].end - ts->tokens[tok].start, parent_id);
 
@@ -599,7 +597,7 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
     // actually write data
     while (tok + 1 < ts->tok_count) {
 
-        struct ts_data_object *object =
+        const struct ts_data_object *object =
             ts_get_object_by_name(ts, ts->json_str + ts->tokens[tok].start,
                 ts->tokens[tok].end - ts->tokens[tok].start, parent_id);
 

--- a/src/thingset_txt.c
+++ b/src/thingset_txt.c
@@ -516,6 +516,7 @@ int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmn
 int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
 {
     int tok = 0;       // current token
+    bool updated = false;
 
     // buffer for data object value (largest negative 64bit integer has 20 digits)
     char value_buf[21];
@@ -612,6 +613,14 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
 
         tok += ts_json_deserialize_value(ts, &ts->json_str[ts->tokens[tok].start], value_len,
             ts->tokens[tok].type, object);
+
+        if (ts->_update_subsets & object->subsets) {
+            updated = true;
+        }
+    }
+
+    if (updated && ts->update_cb != NULL) {
+        ts->update_cb();
     }
 
     return ts_txt_response(ts, TS_STATUS_CHANGED);

--- a/src/ts_config.h
+++ b/src/ts_config.h
@@ -75,4 +75,24 @@
 #define TS_BYTE_STRING_TYPE_SUPPORT CONFIG_THINGSET_BYTE_STRING_TYPE_SUPPORT
 #endif
 
+/*
+ * The ThingSet specification v0.5 introduces a different data layout compared to previous
+ * versions where the data is grouped by entities of the device (like battery, actuator)
+ * instead of the data type (e.g. measurement, configuration). The data type is described by
+ * a single character prefix in the item name.
+ * The new grouping allows to have same item names in different groups, so for unambigous
+ * description of the data the nested structure has to be maintained in statements.
+ *
+ * With nested JSON enabled, requesting names for IDs will also return the entire path (as
+ * a JSON pointer) instead of just the data item name.
+ *
+ * This option is introduced to maintain compatibility with legacy firmware and will be
+ * enabled by default in the future.
+ */
+#if !defined(TS_NESTED_JSON) && !defined(CONFIG_THINGSET_NESTED_JSON)
+#define TS_NESTED_JSON 0        // default: no nested JSON for legacy code
+#elif !defined(TS_NESTED_JSON)
+#define TS_NESTED_JSON CONFIG_THINGSET_NESTED_JSON
+#endif
+
 #endif /* TS_CONFIG_H_ */

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -55,7 +55,7 @@ void tests_text_mode()
     RUN_TEST(test_txt_patch_readonly);
     RUN_TEST(test_txt_patch_wrong_path);
     RUN_TEST(test_txt_patch_unknown_object);
-    RUN_TEST(test_txt_conf_callback);
+    RUN_TEST(test_txt_group_callback);
 
     // POST request
     RUN_TEST(test_txt_exec);
@@ -80,6 +80,9 @@ void tests_text_mode()
 
     // data export
     RUN_TEST(test_txt_export);
+
+    // update notification
+    RUN_TEST(test_txt_update_callback),
 
     UNITY_END();
 }
@@ -127,6 +130,9 @@ void tests_binary_mode()
     // data export/import
     RUN_TEST(test_bin_export);
     RUN_TEST(test_bin_import);
+
+    // update notification
+    RUN_TEST(test_bin_update_callback),
 
     UNITY_END();
 }

--- a/test/test.h
+++ b/test/test.h
@@ -36,6 +36,7 @@ extern "C" {
 
 #define SUBSET_REPORT  (1U << 0)   // report subset of data items for publication
 #define SUBSET_CAN     (1U << 1)   // data nodes used for CAN bus publication messages
+#define SUBSET_NVM     (1U << 2)   // data that should be stored in EEPROM
 
 extern char manufacturer[];
 extern bool pub_report_enable;
@@ -69,13 +70,15 @@ extern struct ts_context ts;
 extern uint8_t req_buf[TS_REQ_BUFFER_LEN];
 extern uint8_t resp_buf[TS_RESP_BUFFER_LEN];
 
-extern bool conf_callback_called;
+extern bool group_callback_called;
+extern bool update_callback_called;
 extern bool dummy_called_flag;
 extern struct ts_array_info pub_serial_array;
 
 /* Helper functions (see test_context.c) */
 void dummy(void);
-void conf_callback(void);
+void group_callback(void);
+void update_callback(void);
 void reset_function(void);
 void auth_function(void);
 int _hex2bin(uint8_t *bin, size_t bin_size, const char *hex);
@@ -142,7 +145,7 @@ void test_txt_patch_array(void);
 void test_txt_patch_readonly(void);
 void test_txt_patch_wrong_path(void);
 void test_txt_patch_unknown_object(void);
-void test_txt_conf_callback(void);
+void test_txt_group_callback(void);
 void test_txt_exec(void);
 void test_txt_statement_subset(void);
 void test_txt_statement_group(void);
@@ -157,6 +160,7 @@ void test_txt_auth_reset(void);
 void test_txt_wrong_command(void);
 void test_txt_get_endpoint(void);
 void test_txt_export(void);
+void test_txt_update_callback(void);
 
 void test_bin_get_meas_ids_values(void);
 void test_bin_get_meas_names_values(void);
@@ -180,6 +184,7 @@ void test_bin_deserialize_bytes(void);
 void test_bin_patch_fetch_bytes(void);
 void test_bin_export(void);
 void test_bin_import(void);
+void test_bin_update_callback(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/test/test.h
+++ b/test/test.h
@@ -36,7 +36,6 @@ extern "C" {
 
 #define SUBSET_REPORT  (1U << 0)   // report subset of data items for publication
 #define SUBSET_CAN     (1U << 1)   // data nodes used for CAN bus publication messages
-#define SUBSET_NVM     (1U << 2)   // data that should be stored in EEPROM
 
 extern char manufacturer[];
 extern bool pub_report_enable;
@@ -158,7 +157,6 @@ void test_txt_auth_reset(void);
 void test_txt_wrong_command(void);
 void test_txt_get_endpoint(void);
 void test_txt_export(void);
-void test_txt_check_updated(void);
 
 void test_bin_get_meas_ids_values(void);
 void test_bin_get_meas_names_values(void);
@@ -182,7 +180,6 @@ void test_bin_deserialize_bytes(void);
 void test_bin_patch_fetch_bytes(void);
 void test_bin_export(void);
 void test_bin_import(void);
-void test_bin_check_updated(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/test/test.h
+++ b/test/test.h
@@ -36,6 +36,7 @@ extern "C" {
 
 #define SUBSET_REPORT  (1U << 0)   // report subset of data items for publication
 #define SUBSET_CAN     (1U << 1)   // data nodes used for CAN bus publication messages
+#define SUBSET_NVM     (1U << 2)   // data that should be stored in EEPROM
 
 extern char manufacturer[];
 extern bool pub_report_enable;
@@ -157,6 +158,7 @@ void test_txt_auth_reset(void);
 void test_txt_wrong_command(void);
 void test_txt_get_endpoint(void);
 void test_txt_export(void);
+void test_txt_check_updated(void);
 
 void test_bin_get_meas_ids_values(void);
 void test_bin_get_meas_names_values(void);
@@ -180,6 +182,7 @@ void test_bin_deserialize_bytes(void);
 void test_bin_patch_fetch_bytes(void);
 void test_bin_export(void);
 void test_bin_import(void);
+void test_bin_check_updated(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/test/test_bin.c
+++ b/test/test_bin.c
@@ -206,8 +206,7 @@ void test_bin_patch_rounded_float(void)
             0x05
     };
     const uint8_t resp_expected[] = {
-        TS_STATUS_CHANGED
-    };
+        TS_STATUS_CHANGED };
 
     TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
 
@@ -436,40 +435,4 @@ void test_bin_export(void)
     int resp_len = ts_bin_export(&ts, resp_buf, sizeof(resp_buf), SUBSET_REPORT);
 
     TEST_ASSERT_BIN_RESP(resp_buf, resp_len, resp_expected);
-}
-
-void test_bin_check_updated(void)
-{
-    bool updated;
-
-    ts_check_updated(&ts, SUBSET_NVM, true);        // clear potential previous flags
-
-    const uint8_t req[] = {
-        TS_PATCH,
-        0x18, ID_CONF,
-        0xA1,
-            0x18, 0x31,
-            0x05
-    };
-    const uint8_t resp_expected[] = {
-        TS_STATUS_CHANGED
-    };
-
-    TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
-
-    /* check for update, but keep the flag */
-    updated = ts_check_updated(&ts, SUBSET_NVM, false);
-    TEST_ASSERT_EQUAL(updated, true);
-
-    /* check other subset to make sure it doesn't trigger */
-    updated = ts_check_updated(&ts, SUBSET_REPORT, false);
-    TEST_ASSERT_EQUAL(updated, false);
-
-    /* now clear the flags during check */
-    updated = ts_check_updated(&ts, SUBSET_NVM, true);
-    TEST_ASSERT_EQUAL(updated, true);
-
-    /* finally no updated values should be reported anymore */
-    updated = ts_check_updated(&ts, SUBSET_NVM, true);
-    TEST_ASSERT_EQUAL(updated, false);
 }

--- a/test/test_bin.c
+++ b/test/test_bin.c
@@ -238,9 +238,8 @@ void test_bin_statement_group(void)
     const char resp_expected[] =
         "1F "
         "01 "                                       // ID of "info"
-        "83 "                                       // array with 3 elements
+        "82 "                                       // array with 2 elements
         "6B 4C 69 62 72 65 20 53 6F 6C 61 72 "      // "Libre Solar"
-        "1A 00 BC 61 4E "                           // int 12345678
         "68 41 42 43 44 31 32 33 34 ";              // "ABCD1234"
 
     int resp_len = ts_bin_statement_by_path(&ts, resp_buf, sizeof(resp_buf), "info");
@@ -428,7 +427,7 @@ void test_bin_export(void)
 {
     const char resp_expected[] =
         "A4 "                       // map with 4 elements
-        "18 1A 1A 00 BC 61 4E "     // int 12345678
+        "10 1A 00 BC 61 4E "        // int 12345678
         "18 71 FA 41 61 99 9a "     // float 14.10
         "18 72 FA 40 a4 28 f6 "     // float 5.13
         "18 73 16 ";                // int 22

--- a/test/test_bin.c
+++ b/test/test_bin.c
@@ -206,7 +206,8 @@ void test_bin_patch_rounded_float(void)
             0x05
     };
     const uint8_t resp_expected[] = {
-        TS_STATUS_CHANGED };
+        TS_STATUS_CHANGED
+    };
 
     TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
 
@@ -435,4 +436,40 @@ void test_bin_export(void)
     int resp_len = ts_bin_export(&ts, resp_buf, sizeof(resp_buf), SUBSET_REPORT);
 
     TEST_ASSERT_BIN_RESP(resp_buf, resp_len, resp_expected);
+}
+
+void test_bin_check_updated(void)
+{
+    bool updated;
+
+    ts_check_updated(&ts, SUBSET_NVM, true);        // clear potential previous flags
+
+    const uint8_t req[] = {
+        TS_PATCH,
+        0x18, ID_CONF,
+        0xA1,
+            0x18, 0x31,
+            0x05
+    };
+    const uint8_t resp_expected[] = {
+        TS_STATUS_CHANGED
+    };
+
+    TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
+
+    /* check for update, but keep the flag */
+    updated = ts_check_updated(&ts, SUBSET_NVM, false);
+    TEST_ASSERT_EQUAL(updated, true);
+
+    /* check other subset to make sure it doesn't trigger */
+    updated = ts_check_updated(&ts, SUBSET_REPORT, false);
+    TEST_ASSERT_EQUAL(updated, false);
+
+    /* now clear the flags during check */
+    updated = ts_check_updated(&ts, SUBSET_NVM, true);
+    TEST_ASSERT_EQUAL(updated, true);
+
+    /* finally no updated values should be reported anymore */
+    updated = ts_check_updated(&ts, SUBSET_NVM, true);
+    TEST_ASSERT_EQUAL(updated, false);
 }

--- a/test/test_bin.c
+++ b/test/test_bin.c
@@ -206,7 +206,8 @@ void test_bin_patch_rounded_float(void)
             0x05
     };
     const uint8_t resp_expected[] = {
-        TS_STATUS_CHANGED };
+        TS_STATUS_CHANGED
+    };
 
     TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
 
@@ -435,4 +436,30 @@ void test_bin_export(void)
     int resp_len = ts_bin_export(&ts, resp_buf, sizeof(resp_buf), SUBSET_REPORT);
 
     TEST_ASSERT_BIN_RESP(resp_buf, resp_len, resp_expected);
+}
+
+void test_bin_update_callback(void)
+{
+    const uint8_t req[] = {
+        TS_PATCH,
+        0x18, ID_CONF,
+        0xA1,
+            0x18, 0x31,
+            0x05
+    };
+    const uint8_t resp_expected[] = {
+        TS_STATUS_CHANGED
+    };
+
+    update_callback_called = false;
+
+    // without callback
+    ts_set_update_callback(&ts, SUBSET_NVM, NULL);
+    TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
+    TEST_ASSERT_EQUAL(false, update_callback_called);
+
+    // with configured callback
+    ts_set_update_callback(&ts, SUBSET_NVM, update_callback);
+    TEST_ASSERT_BIN_REQ_EXP_BIN(req, sizeof(req), resp_expected, sizeof(resp_expected));
+    TEST_ASSERT_EQUAL(true, update_callback_called);
 }

--- a/test/test_context.c
+++ b/test/test_context.c
@@ -12,19 +12,25 @@ struct ts_context ts;
 uint8_t req_buf[TS_REQ_BUFFER_LEN];
 uint8_t resp_buf[TS_RESP_BUFFER_LEN];
 
-bool conf_callback_called;
+bool group_callback_called;
+bool update_callback_called;
 bool dummy_called_flag;
 struct ts_array_info pub_serial_array;
 
 
 void dummy(void)
 {
-    dummy_called_flag = 1;
+    dummy_called_flag = true;
 }
 
-void conf_callback(void)
+void group_callback(void)
 {
-    conf_callback_called = 1;
+    group_callback_called = true;
+}
+
+void update_callback(void)
+{
+    update_callback_called = true;
 }
 
 void reset_function()

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -70,10 +70,6 @@ struct ts_array_info float32_array = {B, sizeof(B)/sizeof(float), 2, TS_T_FLOAT3
 uint8_t bytes[300] = {};
 struct ts_bytes_buffer bytes_buf = { bytes, 0 };
 
-void dummy(void);
-void conf_callback(void);
-
-
 struct ts_data_object data_objects[] = {
 
     TS_ITEM_UINT32(0x10, "t_s", &timestamp,
@@ -87,17 +83,17 @@ struct ts_data_object data_objects[] = {
         ID_INFO, TS_ANY_R, 0),
 
     TS_ITEM_STRING(0x1B, "DeviceID", device_id, sizeof(device_id),
-        ID_INFO, TS_ANY_R | TS_MKR_W, 0),
+        ID_INFO, TS_ANY_R | TS_MKR_W, SUBSET_NVM),
 
     // CONFIGURATION //////////////////////////////////////////////////////////
 
-    TS_GROUP(ID_CONF, "conf", &conf_callback, ID_ROOT),
+    TS_GROUP(ID_CONF, "conf", &group_callback, ID_ROOT),
 
     TS_ITEM_FLOAT(0x31, "BatCharging_V", &bat_charging_voltage, 2,
-        ID_CONF, TS_ANY_RW, 0),
+        ID_CONF, TS_ANY_RW, SUBSET_NVM),
 
     TS_ITEM_FLOAT(0x32, "LoadDisconnect_V", &load_disconnect_voltage, 2,
-        ID_CONF, TS_ANY_RW, 0),
+        ID_CONF, TS_ANY_RW, SUBSET_NVM),
 
     // INPUT DATA /////////////////////////////////////////////////////////////
 

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -87,17 +87,17 @@ struct ts_data_object data_objects[] = {
         ID_INFO, TS_ANY_R, 0),
 
     TS_ITEM_STRING(0x1B, "DeviceID", device_id, sizeof(device_id),
-        ID_INFO, TS_ANY_R | TS_MKR_W, SUBSET_NVM),
+        ID_INFO, TS_ANY_R | TS_MKR_W, 0),
 
     // CONFIGURATION //////////////////////////////////////////////////////////
 
     TS_GROUP(ID_CONF, "conf", &conf_callback, ID_ROOT),
 
     TS_ITEM_FLOAT(0x31, "BatCharging_V", &bat_charging_voltage, 2,
-        ID_CONF, TS_ANY_RW, SUBSET_NVM),
+        ID_CONF, TS_ANY_RW, 0),
 
     TS_ITEM_FLOAT(0x32, "LoadDisconnect_V", &load_disconnect_voltage, 2,
-        ID_CONF, TS_ANY_RW, SUBSET_NVM),
+        ID_CONF, TS_ANY_RW, 0),
 
     // INPUT DATA /////////////////////////////////////////////////////////////
 

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -87,17 +87,17 @@ struct ts_data_object data_objects[] = {
         ID_INFO, TS_ANY_R, 0),
 
     TS_ITEM_STRING(0x1B, "DeviceID", device_id, sizeof(device_id),
-        ID_INFO, TS_ANY_R | TS_MKR_W, 0),
+        ID_INFO, TS_ANY_R | TS_MKR_W, SUBSET_NVM),
 
     // CONFIGURATION //////////////////////////////////////////////////////////
 
     TS_GROUP(ID_CONF, "conf", &conf_callback, ID_ROOT),
 
     TS_ITEM_FLOAT(0x31, "BatCharging_V", &bat_charging_voltage, 2,
-        ID_CONF, TS_ANY_RW, 0),
+        ID_CONF, TS_ANY_RW, SUBSET_NVM),
 
     TS_ITEM_FLOAT(0x32, "LoadDisconnect_V", &load_disconnect_voltage, 2,
-        ID_CONF, TS_ANY_RW, 0),
+        ID_CONF, TS_ANY_RW, SUBSET_NVM),
 
     // INPUT DATA /////////////////////////////////////////////////////////////
 

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -76,15 +76,15 @@ void conf_callback(void);
 
 struct ts_data_object data_objects[] = {
 
+    TS_ITEM_UINT32(0x10, "t_s", &timestamp,
+        ID_ROOT, TS_ANY_RW, SUBSET_REPORT),
+
     // DEVICE INFORMATION /////////////////////////////////////////////////////
 
     TS_GROUP(ID_INFO, "info", TS_NO_CALLBACK, ID_ROOT),
 
     TS_ITEM_STRING(0x19, "Manufacturer", manufacturer, 0,
         ID_INFO, TS_ANY_R, 0),
-
-    TS_ITEM_UINT32(0x1A, "Timestamp_s", &timestamp,
-        ID_INFO, TS_ANY_RW, SUBSET_REPORT),
 
     TS_ITEM_STRING(0x1B, "DeviceID", device_id, sizeof(device_id),
         ID_INFO, TS_ANY_R | TS_MKR_W, 0),

--- a/test/test_shim.cpp
+++ b/test/test_shim.cpp
@@ -9,6 +9,6 @@ void test_shim_get_object(void)
 {
     ThingSet ts(&data_objects[0], data_objects_size);
 
-    ThingSetDataObject *object = ts.get_object(ID_INFO);
+    ThingSetDataObject *object = ts.get_object(0x10);   // timestamp object "t_s"
     TEST_ASSERT_EQUAL_PTR(&data_objects[0], object);
 }

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -96,13 +96,13 @@ void test_txt_patch_unknown_object(void)
     TEST_ASSERT_TXT_REQ("=conf {\"i3\" : 52}", ":A4 Not Found.");
 }
 
-void test_txt_conf_callback(void)
+void test_txt_group_callback(void)
 {
-    conf_callback_called = 0;
+    group_callback_called = false;
 
     TEST_ASSERT_TXT_REQ("=conf {\"i32\":52}", ":84 Changed.");
 
-    TEST_ASSERT_EQUAL(1, conf_callback_called);
+    TEST_ASSERT_EQUAL(true, group_callback_called);
 }
 
 void test_txt_exec(void)
@@ -296,3 +296,18 @@ void test_txt_export(void)
 }
 
 #endif /* TS_NESTED_JSON */
+
+void test_txt_update_callback(void)
+{
+    update_callback_called = false;
+
+    // without callback
+    ts_set_update_callback(&ts, SUBSET_NVM, NULL);
+    TEST_ASSERT_TXT_REQ("=conf {\"BatCharging_V\":52}", ":84 Changed.");
+    TEST_ASSERT_EQUAL(false, update_callback_called);
+
+    // with configured callback
+    ts_set_update_callback(&ts, SUBSET_NVM, update_callback);
+    TEST_ASSERT_TXT_REQ("=conf {\"BatCharging_V\":52}", ":84 Changed.");
+    TEST_ASSERT_EQUAL(true, update_callback_called);
+}

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -276,3 +276,28 @@ void test_txt_export(void)
 }
 
 #endif /* TS_NESTED_JSON */
+
+void test_txt_check_updated(void)
+{
+    bool updated;
+
+    ts_check_updated(&ts, SUBSET_NVM, true);        // clear potential previous flags
+
+    TEST_ASSERT_TXT_REQ("=conf {\"BatCharging_V\":52}", ":84 Changed.");
+
+    /* check for update, but keep the flag */
+    updated = ts_check_updated(&ts, SUBSET_NVM, false);
+    TEST_ASSERT_EQUAL(updated, true);
+
+    /* check other subset to make sure it doesn't trigger */
+    updated = ts_check_updated(&ts, SUBSET_REPORT, false);
+    TEST_ASSERT_EQUAL(updated, false);
+
+    /* now clear the flags during check */
+    updated = ts_check_updated(&ts, SUBSET_NVM, true);
+    TEST_ASSERT_EQUAL(updated, true);
+
+    /* finally no updated values should be reported anymore */
+    updated = ts_check_updated(&ts, SUBSET_NVM, true);
+    TEST_ASSERT_EQUAL(updated, false);
+}

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -114,6 +114,24 @@ void test_txt_exec(void)
     TEST_ASSERT_EQUAL(1, dummy_called_flag);
 }
 
+#if TS_NESTED_JSON
+
+void test_txt_statement_subset(void)
+{
+    const char expected[] = "#report {\"info\":{\"Timestamp_s\":12345678},"
+        "\"meas\":{\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}}";
+
+    int resp_len = ts_txt_statement_by_path(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, "report");
+
+    TEST_ASSERT_TXT_RESP(resp_len, expected);
+
+    resp_len = ts_txt_statement_by_id(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, ID_REPORT);
+
+    TEST_ASSERT_TXT_RESP(resp_len, expected);
+}
+
+#else
+
 void test_txt_statement_subset(void)
 {
     int resp_len = ts_txt_statement_by_path(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, "report");
@@ -124,6 +142,8 @@ void test_txt_statement_subset(void)
 
     TEST_ASSERT_TXT_RESP(resp_len, "#report {\"Timestamp_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
 }
+
+#endif /* TS_NESTED_JSON */
 
 void test_txt_statement_group(void)
 {
@@ -233,9 +253,26 @@ void test_txt_get_endpoint(void)
     TEST_ASSERT_EQUAL_UINT16(0xE1, object->id);
 }
 
+#if TS_NESTED_JSON
+
+void test_txt_export(void)
+{
+    const char expected[] = "{\"info\":{\"Timestamp_s\":12345678},"
+        "\"meas\":{\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}}";
+
+    int resp_len = ts_txt_export(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, SUBSET_REPORT);
+    resp_buf[resp_len] = '\0';
+
+    TEST_ASSERT_TXT_RESP(resp_len, expected);
+}
+
+#else
+
 void test_txt_export(void)
 {
     int resp_len = ts_txt_export(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, SUBSET_REPORT);
 
     TEST_ASSERT_TXT_RESP(resp_len, "{\"Timestamp_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
 }
+
+#endif /* TS_NESTED_JSON */

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -170,6 +170,24 @@ void test_txt_pub_enable(void)
     TEST_ASSERT_TRUE(pub_report_enable);
 }
 
+#if TS_NESTED_JSON
+
+void test_txt_pub_delete_append_object(void)
+{
+    /* before change */
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"meas/Bat_V\",\"meas/Bat_A\",\"meas/Ambient_degC\"]");
+    /* delete "Ambient_degC" */
+    TEST_ASSERT_TXT_REQ("-report \"meas/Ambient_degC\"", ":82 Deleted.");
+    /* check if it was deleted */
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"meas/Bat_V\",\"meas/Bat_A\"]");
+    /* append "Ambient_degC" again */
+    TEST_ASSERT_TXT_REQ("+report \"meas/Ambient_degC\"", ":81 Created.");
+    /* check if it was appended */
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"meas/Bat_V\",\"meas/Bat_A\",\"meas/Ambient_degC\"]");
+}
+
+#else
+
 void test_txt_pub_delete_append_object(void)
 {
     /* before change */
@@ -183,6 +201,8 @@ void test_txt_pub_delete_append_object(void)
     /* check if it was appended */
     TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"Bat_V\",\"Bat_A\",\"Ambient_degC\"]");
 }
+
+#endif /* TS_NESTED_JSON */
 
 void test_txt_auth_user(void)
 {

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -118,7 +118,7 @@ void test_txt_exec(void)
 
 void test_txt_statement_subset(void)
 {
-    const char expected[] = "#report {\"info\":{\"Timestamp_s\":12345678},"
+    const char expected[] = "#report {\"t_s\":12345678,"
         "\"meas\":{\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}}";
 
     int resp_len = ts_txt_statement_by_path(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, "report");
@@ -136,11 +136,11 @@ void test_txt_statement_subset(void)
 {
     int resp_len = ts_txt_statement_by_path(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, "report");
 
-    TEST_ASSERT_TXT_RESP(resp_len, "#report {\"Timestamp_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
+    TEST_ASSERT_TXT_RESP(resp_len, "#report {\"t_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
 
     resp_len = ts_txt_statement_by_id(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, ID_REPORT);
 
-    TEST_ASSERT_TXT_RESP(resp_len, "#report {\"Timestamp_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
+    TEST_ASSERT_TXT_RESP(resp_len, "#report {\"t_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
 }
 
 #endif /* TS_NESTED_JSON */
@@ -149,11 +149,11 @@ void test_txt_statement_group(void)
 {
     int resp_len = ts_txt_statement_by_path(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, "info");
 
-    TEST_ASSERT_TXT_RESP(resp_len, "#info {\"Manufacturer\":\"Libre Solar\",\"Timestamp_s\":12345678,\"DeviceID\":\"ABCD1234\"}");
+    TEST_ASSERT_TXT_RESP(resp_len, "#info {\"Manufacturer\":\"Libre Solar\",\"DeviceID\":\"ABCD1234\"}");
 
     resp_len = ts_txt_statement_by_id(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, ID_INFO);
 
-    TEST_ASSERT_TXT_RESP(resp_len, "#info {\"Manufacturer\":\"Libre Solar\",\"Timestamp_s\":12345678,\"DeviceID\":\"ABCD1234\"}");
+    TEST_ASSERT_TXT_RESP(resp_len, "#info {\"Manufacturer\":\"Libre Solar\",\"DeviceID\":\"ABCD1234\"}");
 }
 
 void test_txt_pub_list_channels(void)
@@ -173,15 +173,15 @@ void test_txt_pub_enable(void)
 void test_txt_pub_delete_append_object(void)
 {
     /* before change */
-    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"Timestamp_s\",\"Bat_V\",\"Bat_A\",\"Ambient_degC\"]");
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"Bat_V\",\"Bat_A\",\"Ambient_degC\"]");
     /* delete "Ambient_degC" */
     TEST_ASSERT_TXT_REQ("-report \"Ambient_degC\"", ":82 Deleted.");
     /* check if it was deleted */
-    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"Timestamp_s\",\"Bat_V\",\"Bat_A\"]");
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"Bat_V\",\"Bat_A\"]");
     /* append "Ambient_degC" again */
     TEST_ASSERT_TXT_REQ("+report \"Ambient_degC\"", ":81 Created.");
     /* check if it was appended */
-    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"Timestamp_s\",\"Bat_V\",\"Bat_A\",\"Ambient_degC\"]");
+    TEST_ASSERT_TXT_REQ("?report", ":85 Content. [\"t_s\",\"Bat_V\",\"Bat_A\",\"Ambient_degC\"]");
 }
 
 void test_txt_auth_user(void)
@@ -257,8 +257,8 @@ void test_txt_get_endpoint(void)
 
 void test_txt_export(void)
 {
-    const char expected[] = "{\"info\":{\"Timestamp_s\":12345678},"
-        "\"meas\":{\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}}";
+    const char expected[] =
+        "{\"t_s\":12345678,\"meas\":{\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}}";
 
     int resp_len = ts_txt_export(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, SUBSET_REPORT);
     resp_buf[resp_len] = '\0';
@@ -272,7 +272,7 @@ void test_txt_export(void)
 {
     int resp_len = ts_txt_export(&ts, (char *)resp_buf, TS_RESP_BUFFER_LEN, SUBSET_REPORT);
 
-    TEST_ASSERT_TXT_RESP(resp_len, "{\"Timestamp_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
+    TEST_ASSERT_TXT_RESP(resp_len, "{\"t_s\":12345678,\"Bat_V\":14.10,\"Bat_A\":5.13,\"Ambient_degC\":22}");
 }
 
 #endif /* TS_NESTED_JSON */

--- a/test/test_txt.c
+++ b/test/test_txt.c
@@ -296,28 +296,3 @@ void test_txt_export(void)
 }
 
 #endif /* TS_NESTED_JSON */
-
-void test_txt_check_updated(void)
-{
-    bool updated;
-
-    ts_check_updated(&ts, SUBSET_NVM, true);        // clear potential previous flags
-
-    TEST_ASSERT_TXT_REQ("=conf {\"BatCharging_V\":52}", ":84 Changed.");
-
-    /* check for update, but keep the flag */
-    updated = ts_check_updated(&ts, SUBSET_NVM, false);
-    TEST_ASSERT_EQUAL(updated, true);
-
-    /* check other subset to make sure it doesn't trigger */
-    updated = ts_check_updated(&ts, SUBSET_REPORT, false);
-    TEST_ASSERT_EQUAL(updated, false);
-
-    /* now clear the flags during check */
-    updated = ts_check_updated(&ts, SUBSET_NVM, true);
-    TEST_ASSERT_EQUAL(updated, true);
-
-    /* finally no updated values should be reported anymore */
-    updated = ts_check_updated(&ts, SUBSET_NVM, true);
-    TEST_ASSERT_EQUAL(updated, false);
-}

--- a/zephyr/Kconfig.thingset
+++ b/zephyr/Kconfig.thingset
@@ -58,6 +58,23 @@ config THINGSET_CPP_LEGACY
           ThingSet protocol library. Enable if your C++ code uses
           DataNode or ArrayInfo instead of ThingSetDataNode or ThingSetArrayInfo.
 
+config THINGSET_NESTED_JSON
+        bool "Use nested JSON for statements"
+        default n
+        help
+          The ThingSet specification v0.5 introduces a different data layout compared to previous
+          versions where the data is grouped by entities of the device (like battery, actuator)
+          instead of the data type (e.g. measurement, configuration). The data type is described by
+          a single character prefix in the item name.
+          The new grouping allows to have same item names in different groups, so for unambigous
+          description of the data the nested structure has to be maintained in statements.
+
+          With nested JSON enabled, requesting names for IDs will also return the entire path (as
+          a JSON pointer) instead of just the data item name.
+
+          This option is introduced to maintain compatibility with legacy firmware and will be
+          enabled by default in the future.
+
 module = THINGSET
 module-str = thingset
 source "subsys/logging/Kconfig.template.log_config"

--- a/zephyr/tests/src/main.c
+++ b/zephyr/tests/src/main.c
@@ -47,7 +47,7 @@ void test_main(void)
         ztest_unit_test_setup_teardown(test_txt_patch_readonly, setup, teardown),
         ztest_unit_test_setup_teardown(test_txt_patch_wrong_path, setup, teardown),
         ztest_unit_test_setup_teardown(test_txt_patch_unknown_object, setup, teardown),
-        ztest_unit_test_setup_teardown(test_txt_conf_callback, setup, teardown),
+        ztest_unit_test_setup_teardown(test_txt_group_callback, setup, teardown),
         /* Text mode: POST request */
         ztest_unit_test_setup_teardown(test_txt_exec, setup, teardown),
         /* Text mode: statements (pub/sub messages) */
@@ -66,6 +66,8 @@ void test_main(void)
         ztest_unit_test_setup_teardown(test_txt_get_endpoint, setup, teardown),
         /* Text mode: exporting of data */
         ztest_unit_test_setup_teardown(test_txt_export, setup, teardown),
+        /* Text mode: update notification */
+        ztest_unit_test_setup_teardown(test_txt_update_callback, setup, teardown),
 
         /* Bin mode: GET request */
         ztest_unit_test_setup_teardown(test_bin_get_meas_ids_values, setup, teardown),
@@ -98,7 +100,9 @@ void test_main(void)
 #endif
         /* Bin mode: exporting/importing of data */
         ztest_unit_test_setup_teardown(test_bin_export, setup, teardown),
-        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown)
+        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown),
+        /* Bin mode: update notification */
+        ztest_unit_test_setup_teardown(test_bin_update_callback, setup, teardown)
     );
 
     ztest_run_test_suite(thingset_tests);

--- a/zephyr/tests/src/main.c
+++ b/zephyr/tests/src/main.c
@@ -66,6 +66,8 @@ void test_main(void)
         ztest_unit_test_setup_teardown(test_txt_get_endpoint, setup, teardown),
         /* Text mode: exporting of data */
         ztest_unit_test_setup_teardown(test_txt_export, setup, teardown),
+        /* Text mode: storing updates of data */
+        ztest_unit_test_setup_teardown(test_txt_check_updated, setup, teardown),
 
         /* Bin mode: GET request */
         ztest_unit_test_setup_teardown(test_bin_get_meas_ids_values, setup, teardown),
@@ -98,7 +100,9 @@ void test_main(void)
 #endif
         /* Bin mode: exporting/importing of data */
         ztest_unit_test_setup_teardown(test_bin_export, setup, teardown),
-        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown)
+        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown),
+        /* Bin mode: storing updates of data */
+        ztest_unit_test_setup_teardown(test_bin_check_updated, setup, teardown)
     );
 
     ztest_run_test_suite(thingset_tests);

--- a/zephyr/tests/src/main.c
+++ b/zephyr/tests/src/main.c
@@ -66,8 +66,6 @@ void test_main(void)
         ztest_unit_test_setup_teardown(test_txt_get_endpoint, setup, teardown),
         /* Text mode: exporting of data */
         ztest_unit_test_setup_teardown(test_txt_export, setup, teardown),
-        /* Text mode: storing updates of data */
-        ztest_unit_test_setup_teardown(test_txt_check_updated, setup, teardown),
 
         /* Bin mode: GET request */
         ztest_unit_test_setup_teardown(test_bin_get_meas_ids_values, setup, teardown),
@@ -100,9 +98,7 @@ void test_main(void)
 #endif
         /* Bin mode: exporting/importing of data */
         ztest_unit_test_setup_teardown(test_bin_export, setup, teardown),
-        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown),
-        /* Bin mode: storing updates of data */
-        ztest_unit_test_setup_teardown(test_bin_check_updated, setup, teardown)
+        ztest_unit_test_setup_teardown(test_bin_import, setup, teardown)
     );
 
     ztest_run_test_suite(thingset_tests);


### PR DESCRIPTION
## Background

While developing a mobile phone app that translates ThingSet data objects read from a device into a user interface, I realized several shortcomings with the approach of structuring the data into categories like `info`, `conf`, `meas`, etc. Most importantly, it was not semantically clear which data items could be written, so an app would have to try writing a value, process the response and if it is allowed to write the value, display it in a text box so that it can be changed via the UI.

The v0.5 spec introduces prefixes for data items which define if an item is write-able, read-only, executable, stored in RAM or flash, etc. This makes the previous categories obsolete and data can be structured more logically based on features of the device.

An example using the new data structure can be seen in [ThingSet Spec v0.5 (draft)](https://thingset.io/spec/v0.5/appl_data_structure.html#example-data). Also consider the section "User interface processing" at the end.

As data item names don't have to be globally unique anymore (e.g. there can be a measured current for the battery `Bat/rMeas_A` and the load `Load/rMeas_A`) the JSON in the statement messages needs to be nested.

## What does this PR change

1. An option `TS_NESTED_JSON` (or `CONFIG_THINGSET_NESTED_JSON` for Zephyr) is introduced which activates nested JSON for statements (see also comments in the code for the option). For compatibility reasons, the option is disabled by default.
2. If `TS_NESTED_JSON` is enabled, references in subsets use the path to an item (e.g. `Bat/rMeas_A`) instead of just the name (`rMeas_A`).
3. As configuration cannot be stored to EEPROM or flash via a callback anymore (config items can be anywhere and not just in config group) a new `updated` bit is introduced for each data item.
4. The `struct ts_data_objects` is updated to use bitsets for reduced memory footprint. By doing this, we save 4 bytes for each data object in flash and RAM even though we added above mentioned `updated` bit parameter to be stored.

In order to reduce noise in the PR, the new naming schema with prefixes is not fully adapted for the unit tests. I might update the test data in a dedicated PR without functional changes.

## Additional information

@daniel-connectedenergy Commit 7ce2093e2686625d359c8ad03dc878e19dcf9797 will be most interesting for you as it reduces memory footprint with zero effort.