### PR TITLE
Fix string length check in txt_patch function

### DIFF
--- a/src/thingset_txt.c
+++ b/src/thingset_txt.c
@@ -550,9 +550,17 @@ int ts_txt_patch(struct ts_context *ts, const struct ts_data_object *parent)
 
         // extract the value and check buffer lengths
         value_len = ts->tokens[tok].end - ts->tokens[tok].start;
-        if ((object->type != TS_T_STRING && value_len >= sizeof(value_buf)) ||
-            (object->type == TS_T_STRING && value_len >= (size_t)object->detail))
-        {
+        if (object->type == TS_T_STRING) {
+            if (value_len < (size_t)object->detail) {
+                // provided string fits into data object buffer
+                tok += 1;
+                continue;
+            }
+            else {
+                return ts_txt_response(ts, TS_STATUS_REQUEST_TOO_LARGE);
+            }
+        }
+        else if (value_len >= sizeof(value_buf)) {
             return ts_txt_response(ts, TS_STATUS_UNSUPPORTED_FORMAT);
         }
         else {


### PR DESCRIPTION
The previous implementation tried to copy a JSON string value into the
small temporary buffer of 21 bytes if the string was short enough to
fit into the actual data object buffer. The resulted in a buffer overflow.

In addition to that, it's not necessary to copy the string to check if
the buffer is large enough.

This commit fixes the string data object check and avoids the buffer
overflow.