### PR TITLE
Remove C compat. headers to fix C++ compiler issues

### DIFF
--- a/src/thingset.h
+++ b/src/thingset.h
@@ -11,20 +11,12 @@
 #include "ts_config.h"
 
 #ifdef __cplusplus
-/* C++ library setup */
 extern "C" {
+#endif
 
-#include <cstddef>
-#include <cstdint>
-#include <cstdbool>
-
-#else
-/* C library setup */
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-
-#endif
 
 #include "jsmn.h"
 #include "cbor.h"


### PR DESCRIPTION
<cstdbool> is sometimes not found and deprecated. C++ compilers can also
provide the standard C headers like stdbool.h.

Fixes #27

Ping @cfoucher-laas