### PR TITLE
Use GCC builtin lroundf for minimal libc

### DIFF
--- a/zephyr/libc/minimal/extensions.c
+++ b/zephyr/libc/minimal/extensions.c
@@ -6,6 +6,20 @@
 
 #include "../../thingset_zephyr.h"
 
+#if CONFIG_MINIMAL_LIBC
+
+long int lroundf(float x)
+{
+    return __builtin_lroundf(x);
+};
+
+long long int llroundf(float x)
+{
+    return __builtin_llroundf(x);
+};
+
+#endif /* CONFIG_MINIMAL_LIBC */
+
 /*
  * strtod.c --
  *

--- a/zephyr/thingset_zephyr.h
+++ b/zephyr/thingset_zephyr.h
@@ -41,10 +41,9 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #define isnan(value) __builtin_isnan(value)
 #define isinf(value) __builtin_isinf(value)
 
-inline long long int llroundf(float x)
-{
-    return __builtin_llroundf(x);
-};
+long int lroundf(float x);
+
+long long int llroundf(float x);
 
 double ts_strtod(const char * string, char **endPtr);
 inline double strtod(const char * string, char **endPtr)


### PR DESCRIPTION
This avoids requiring the full libc also if 64-bit types are disabled.

For some reason the inlined function failed to compile with Espressif toolchain for RISC-V MCUs (ESP32-C3), so I moved the functions to the .c file.

Fixes #25