### PR TITLE
Add 8-bit integer data types

### DIFF
--- a/src/cbor.c
+++ b/src/cbor.c
@@ -405,6 +405,30 @@ int cbor_deserialize_int16(const uint8_t *data, int16_t *value)
     return 0;
 }
 
+int cbor_deserialize_uint8(const uint8_t *data, uint8_t *value)
+{
+    uint32_t tmp;
+    int size = cbor_deserialize_uint32(data, &tmp); // also checks value for null-pointer
+
+    if (size > 0 && tmp <= UINT8_MAX) {
+        *value = tmp;
+        return size;
+    }
+    return 0;
+}
+
+int cbor_deserialize_int8(const uint8_t *data, int8_t *value)
+{
+    int32_t tmp;
+    int size = cbor_deserialize_int32(data, &tmp); // also checks value for null-pointer
+
+    if (size > 0 && tmp <= INT8_MAX && tmp >= INT8_MIN) {
+        *value = tmp;
+        return size;
+    }
+    return 0;
+}
+
 #if TS_DECFRAC_TYPE_SUPPORT
 int cbor_deserialize_decfrac(const uint8_t *data, int32_t *mantissa, const int16_t exponent)
 {

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -232,6 +232,26 @@ int cbor_deserialize_uint16(const uint8_t *data, uint16_t *value);
 int cbor_deserialize_int16(const uint8_t *data, int16_t *value);
 
 /**
+ * Deserialize 8-bit unsigned integer
+ *
+ * @param data Buffer containing CBOR data with matching type
+ * @param value Pointer to the variable where the value should be stored
+ *
+ * @returns Number of bytes read from buffer or 0 in case of error
+ */
+int cbor_deserialize_uint8(const uint8_t *data, uint8_t *value);
+
+/**
+ * Deserialize 8-bit signed integer
+ *
+ * @param data Buffer containing CBOR data with matching type
+ * @param value Pointer to the variable where the value should be stored
+ *
+ * @returns Number of bytes read from buffer or 0 in case of error
+ */
+int cbor_deserialize_int8(const uint8_t *data, int8_t *value);
+
+/**
  * Deserialize decimal fraction type
  *
  * The exponent is fixed, so the mantissa is multiplied to match the exponent

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -155,6 +155,8 @@ enum TsType {
     TS_T_INT32,     /**< int32_t */
     TS_T_UINT16,    /**< uint16_t */
     TS_T_INT16,     /**< int16_t */
+    TS_T_UINT8,     /**< uint8_t */
+    TS_T_INT8,      /**< int8_t */
     TS_T_FLOAT32,   /**< float */
     TS_T_STRING,    /**< String buffer (UTF-8 text) */
     TS_T_BYTES,     /**< Byte buffer (binary data) */
@@ -218,6 +220,8 @@ static inline void *ts_uint32_to_void(uint32_t *ptr) { return (void*) ptr; }
 static inline void *ts_int32_to_void(int32_t *ptr) { return (void*) ptr; }
 static inline void *ts_uint16_to_void(uint16_t *ptr) { return (void*) ptr; }
 static inline void *ts_int16_to_void(int16_t *ptr) { return (void*) ptr; }
+static inline void *ts_uint8_to_void(uint8_t *ptr) { return (void*) ptr; }
+static inline void *ts_int8_to_void(int8_t *ptr) { return (void*) ptr; }
 static inline void *ts_float_to_void(float *ptr) { return (void*) ptr; }
 static inline void *ts_string_to_void(const char *ptr) { return (void*) ptr; }
 static inline void *ts_bytes_to_void(struct ts_bytes_buffer *ptr) { return (void *) ptr; }
@@ -232,6 +236,8 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define ts_int32_to_void(ptr) ((void*)ptr)
 #define ts_uint16_to_void(ptr) ((void*)ptr)
 #define ts_int16_to_void(ptr) ((void*)ptr)
+#define ts_uint8_to_void(ptr) ((void*)ptr)
+#define ts_int8_to_void(ptr) ((void*)ptr)
 #define ts_float_to_void(ptr) ((void*)ptr)
 #define ts_string_to_void(ptr) ((void*)ptr)
 #define ts_bytes_to_void(ptr) ((void*)ptr)
@@ -270,13 +276,21 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_ITEM_INT16(id, name, int16_ptr, parent_id, access, subsets) \
     {id, parent_id, name, ts_int16_to_void(int16_ptr), TS_T_INT16, 0, access, subsets}
 
+/** Create data item for uint8_t variable. */
+#define TS_ITEM_UINT8(id, name, uint8_ptr, parent_id, access, subsets) \
+    {id, parent_id, name, ts_uint8_to_void(uint8_ptr), TS_T_UINT8, 0, access, subsets}
+
+/** Create data item for int8_t variable. */
+#define TS_ITEM_INT8(id, name, int8_ptr, parent_id, access, subsets) \
+    {id, parent_id, name, ts_int8_to_void(int8_ptr), TS_T_INT8, 0, access, subsets}
+
 /** Create data item for float variable. */
 #define TS_ITEM_FLOAT(id, name, float_ptr, digits, parent_id, access, subsets) \
     {id, parent_id, name, ts_float_to_void(float_ptr), TS_T_FLOAT32, digits, access, subsets}
 
 /**
  * Create data item for decimal fraction variable. The mantissa is internally stored as int32_t.
- * The value is cnverted into a float (JSON) or decimal fraction type (CBOR) for the protocol,
+ * The value is converted into a float (JSON) or decimal fraction type (CBOR) for the protocol,
  * based on the specified (fixed) exponent.
  */
 #define TS_ITEM_DECFRAC(id, name, mantissa_ptr, exponent, parent_id, access, subsets) \
@@ -346,6 +360,14 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_RECORD_ITEM_INT16(parent_id, id, name, struct_type, struct_member) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT16, 0}
 
+/** Create data item for uint8_t variable. */
+#define TS_RECORD_ITEM_UINT8(parent_id, id, name, struct_type, struct_member) \
+    {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_UINT8, 0}
+
+/** Create data item for int8_t variable. */
+#define TS_RECORD_ITEM_INT8(parent_id, id, name, struct_type, struct_member) \
+    {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT8, 0}
+
 /** Create data item for float variable. */
 #define TS_RECORD_ITEM_FLOAT(parent_id, id, name, struct_type, struct_member, digits) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_FLOAT32, digits}
@@ -386,6 +408,8 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_ADD_ITEM_INT32(id, ...)      _TS_ADD_ITERABLE(ITEM_INT32, id, __VA_ARGS__)
 #define TS_ADD_ITEM_UINT16(id, ...)     _TS_ADD_ITERABLE(ITEM_UINT16, id, __VA_ARGS__)
 #define TS_ADD_ITEM_INT16(id, ...)      _TS_ADD_ITERABLE(ITEM_INT16, id, __VA_ARGS__)
+#define TS_ADD_ITEM_UINT8(id, ...)      _TS_ADD_ITERABLE(ITEM_UINT8, id, __VA_ARGS__)
+#define TS_ADD_ITEM_INT8(id, ...)       _TS_ADD_ITERABLE(ITEM_INT8, id, __VA_ARGS__)
 #define TS_ADD_ITEM_FLOAT(id, ...)      _TS_ADD_ITERABLE(ITEM_FLOAT, id, __VA_ARGS__)
 #define TS_ADD_ITEM_DECFRAC(id, ...)    _TS_ADD_ITERABLE(ITEM_DECFRAC, id, __VA_ARGS__)
 #define TS_ADD_ITEM_STRING(id, ...)     _TS_ADD_ITERABLE(ITEM_STRING, id, __VA_ARGS__)
@@ -543,7 +567,7 @@ struct ts_data_object {
     /**
      * One of TS_TYPE_INT32, _FLOAT, ...
      */
-    const uint32_t type : 4;
+    const uint32_t type : 5;
 
     /**
      * Variable storing different detail information depending on the data type
@@ -566,7 +590,7 @@ struct ts_data_object {
     /**
      * Flags to assign data item to different data item subsets (e.g. for publication messages)
      */
-    uint32_t subsets : 8;
+    uint32_t subsets : 7;
 
 };
 

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -31,6 +31,10 @@ static int cbor_deserialize_simple_value(const uint8_t *buf, void *data, int typ
         return cbor_deserialize_uint16(buf, (uint16_t *)data);
     case TS_T_INT16:
         return cbor_deserialize_int16(buf, (int16_t *)data);
+    case TS_T_UINT8:
+        return cbor_deserialize_uint8(buf, (uint8_t *)data);
+    case TS_T_INT8:
+        return cbor_deserialize_int8(buf, (int8_t *)data);
     case TS_T_FLOAT32:
         return cbor_deserialize_float(buf, (float *)data);
 #if TS_DECFRAC_TYPE_SUPPORT
@@ -100,6 +104,10 @@ static int cbor_serialize_simple_value(uint8_t *buf, size_t size, void *data, in
         return cbor_serialize_uint(buf, *((uint16_t *)data), size);
     case TS_T_INT16:
         return cbor_serialize_int(buf, *((int16_t *)data), size);
+    case TS_T_UINT8:
+        return cbor_serialize_uint(buf, *((uint8_t *)data), size);
+    case TS_T_INT8:
+        return cbor_serialize_int(buf, *((int8_t *)data), size);
     case TS_T_FLOAT32:
         if (detail == 0) { // round to 0 digits: use int
 #if TS_64BIT_TYPES_SUPPORT

--- a/src/thingset_txt.c
+++ b/src/thingset_txt.c
@@ -109,6 +109,10 @@ static int json_serialize_simple_value(char *buf, size_t size, void *data, int t
         return snprintf(buf, size, "%" PRIu16 ",", *((uint16_t *)data));
     case TS_T_INT16:
         return snprintf(buf, size, "%" PRIi16 ",", *((int16_t *)data));
+    case TS_T_UINT8:
+        return snprintf(buf, size, "%" PRIu8 ",", *((uint8_t *)data));
+    case TS_T_INT8:
+        return snprintf(buf, size, "%" PRIi8 ",", *((int8_t *)data));
     case TS_T_FLOAT32: {
         float value = *((float *)data);
         if (isnan(value) || isinf(value)) {
@@ -450,6 +454,12 @@ int ts_json_deserialize_value(struct ts_context *ts, char *buf, size_t len, jsmn
             break;
         case TS_T_INT16:
             *((uint16_t*)object->data) = strtol(buf, NULL, 0);
+            break;
+        case TS_T_UINT8:
+            *((uint8_t*)object->data) = strtoul(buf, NULL, 0);
+            break;
+        case TS_T_INT8:
+            *((uint8_t*)object->data) = strtol(buf, NULL, 0);
             break;
         case TS_T_BOOL:
             if (buf[0] == 't' || buf[0] == '1') {

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -52,6 +52,12 @@ void test_assert(void)
  */
 void test_txt_patch_bin_fetch(void)
 {
+    // uint8
+    TEST_ASSERT_JSON2CBOR("ui8", "0", 0x600C, "00");
+    TEST_ASSERT_JSON2CBOR("ui8", "23", 0x600C, "17");
+    TEST_ASSERT_JSON2CBOR("ui8", "24", 0x600C, "18 18");
+    TEST_ASSERT_JSON2CBOR("ui8", "255", 0x600C, "18 ff");
+
     // uint16
     TEST_ASSERT_JSON2CBOR("ui16", "0", 0x6005, "00");
     TEST_ASSERT_JSON2CBOR("ui16", "23", 0x6005, "17");
@@ -77,6 +83,12 @@ void test_txt_patch_bin_fetch(void)
     TEST_ASSERT_JSON2CBOR("ui64", "9223372036854775807", 0x6001, "1B 7F FF FF FF FF FF FF FF"); // maximum value for int64
 #endif
 
+    // int8 (positive values)
+    TEST_ASSERT_JSON2CBOR("i8", "0", 0x600D, "00");
+    TEST_ASSERT_JSON2CBOR("i8", "23", 0x600D, "17");
+    TEST_ASSERT_JSON2CBOR("i8", "24", 0x600D, "18 18");
+    TEST_ASSERT_JSON2CBOR("i8", "127", 0x600D, "18 7f");                       // maximum value for int8
+
     // int16 (positive values)
     TEST_ASSERT_JSON2CBOR("i16", "0", 0x6006, "00");
     TEST_ASSERT_JSON2CBOR("i16", "23", 0x6006, "17");
@@ -101,6 +113,12 @@ void test_txt_patch_bin_fetch(void)
     TEST_ASSERT_JSON2CBOR("i64", "4294967296", 0x6002, "1B 00 00 00 01 00 00 00 00");
     TEST_ASSERT_JSON2CBOR("i64", "9223372036854775807", 0x6002, "1B 7F FF FF FF FF FF FF FF"); // maximum value for int64
 #endif
+
+    // int8 (negative values)
+    TEST_ASSERT_JSON2CBOR("i8", "-0", 0x600D, "00");
+    TEST_ASSERT_JSON2CBOR("i8", "-24", 0x600D, "37");
+    TEST_ASSERT_JSON2CBOR("i8", "-25", 0x600D, "38 18");
+    TEST_ASSERT_JSON2CBOR("i8", "-128", 0x600D, "38 7F");
 
     // int16 (negative values)
     TEST_ASSERT_JSON2CBOR("i16", "-0", 0x6006, "00");
@@ -151,6 +169,14 @@ void test_txt_patch_bin_fetch(void)
  */
 void test_bin_patch_txt_fetch(void)
 {
+    // uint8
+    TEST_ASSERT_CBOR2JSON("ui8", "0", 0x600C, "00");
+    TEST_ASSERT_CBOR2JSON("ui8", "23", 0x600C, "17");
+    TEST_ASSERT_CBOR2JSON("ui8", "23", 0x600C, "18 17");       // less compact format
+    TEST_ASSERT_CBOR2JSON("ui8", "24", 0x600C, "18 18");
+    TEST_ASSERT_CBOR2JSON("ui8", "255", 0x600C, "18 ff");
+    TEST_ASSERT_CBOR2JSON("ui8", "255", 0x600C, "19 00 ff");   // less compact format
+
     // uint16
     TEST_ASSERT_CBOR2JSON("ui16", "0", 0x6005, "00");
     TEST_ASSERT_CBOR2JSON("ui16", "23", 0x6005, "17");
@@ -182,6 +208,23 @@ void test_bin_patch_txt_fetch(void)
     TEST_ASSERT_CBOR2JSON("ui64", "18446744073709551615", 0x6001, "1B FF FF FF FF FF FF FF FF");
 #endif
 
+    // int8 (positive values)
+    TEST_ASSERT_CBOR2JSON("i8", "23", 0x600D, "17");
+    TEST_ASSERT_CBOR2JSON("i8", "23", 0x600D, "18 17");       // less compact format
+    TEST_ASSERT_CBOR2JSON("i8", "24", 0x600D, "18 18");
+    TEST_ASSERT_CBOR2JSON("i8", "127", 0x600D, "18 7F");
+    TEST_ASSERT_CBOR2JSON("i8", "127", 0x600D, "19 00 7F");   // less compact format
+
+    // int16 (positive values)
+    TEST_ASSERT_CBOR2JSON("i16", "23", 0x6006, "17");
+    TEST_ASSERT_CBOR2JSON("i16", "23", 0x6006, "18 17");       // less compact format
+    TEST_ASSERT_CBOR2JSON("i16", "24", 0x6006, "18 18");
+    TEST_ASSERT_CBOR2JSON("i16", "255", 0x6006, "18 FF");
+    TEST_ASSERT_CBOR2JSON("i16", "255", 0x6006, "19 00 FF");   // less compact format
+    TEST_ASSERT_CBOR2JSON("i16", "256", 0x6006, "19 01 00");
+    TEST_ASSERT_CBOR2JSON("i16", "32767", 0x6006, "19 7F FF");
+    TEST_ASSERT_CBOR2JSON("i16", "32767", 0x6006, "1A 00 00 7F FF");  // less compact format
+
     // int32 (positive values)
     TEST_ASSERT_CBOR2JSON("i32", "23", 0x6004, "17");
     TEST_ASSERT_CBOR2JSON("i32", "23", 0x6004, "18 17");       // less compact format
@@ -200,6 +243,12 @@ void test_bin_patch_txt_fetch(void)
     TEST_ASSERT_CBOR2JSON("i64", "4294967296", 0x6002, "1B 00 00 00 01 00 00 00 00");
     TEST_ASSERT_CBOR2JSON("i64", "9223372036854775807", 0x6002, "1B 7F FF FF FF FF FF FF FF"); // maximum value for int64
 #endif
+
+    // int8 (negative values)
+    TEST_ASSERT_CBOR2JSON("i8", "-24", 0x600D, "37");
+    TEST_ASSERT_CBOR2JSON("i8", "-24", 0x600D, "38 17");      // less compact format
+    TEST_ASSERT_CBOR2JSON("i8", "-25", 0x600D, "38 18");
+    TEST_ASSERT_CBOR2JSON("i8", "-128", 0x600D, "38 7f");
 
     // int16 (negative values)
     TEST_ASSERT_CBOR2JSON("i16", "-24", 0x6006, "37");

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -59,6 +59,9 @@ int32_t i32;
 static uint16_t ui16;
 static int16_t i16;
 
+static uint16_t ui8;
+static int16_t i8;
+
 bool b;
 
 int32_t A[100] = {4, 2, 8, 4};
@@ -224,6 +227,8 @@ struct ts_data_object data_objects[] = {
     TS_ITEM_INT32(0x6004, "i32", &i32, ID_CONF, TS_ANY_RW, 0),
     TS_ITEM_UINT16(0x6005, "ui16", &ui16, ID_CONF, TS_ANY_RW, 0),
     TS_ITEM_INT16(0x6006, "i16", &i16, ID_CONF, TS_ANY_RW, 0),
+    TS_ITEM_UINT8(0x600C, "ui8", &ui8, ID_CONF, TS_ANY_RW, 0),
+    TS_ITEM_INT8(0x600D, "i8", &i8, ID_CONF, TS_ANY_RW, 0),
     TS_ITEM_FLOAT(0x6007, "f32", &f32, 2, ID_CONF, TS_ANY_RW, 0),
     TS_ITEM_BOOL(0x6008, "bool", &b, ID_CONF, TS_ANY_RW, 0),
 


### PR DESCRIPTION
This change requires to add another bit to the `type` variable in the `struct data_objects` as the number of supported types exceeds 16.
Stealing it from the `subsets` field seemed like the best idea, as 7 different subsets should be sufficient.

Also adding a few missing `int16_t` unit tests.