### PR TITLE
Support for records in iterable sections

### DIFF
--- a/src/thingset.h
+++ b/src/thingset.h
@@ -333,43 +333,43 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 /** struct related macros */
 
 /** Create data item for bool variable. */
-#define TS_RECORD_ITEM_BOOL(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_BOOL(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_BOOL, 0}
 
 /** Create data item for uint64_t variable. */
-#define TS_RECORD_ITEM_UINT64(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_UINT64(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_UINT64, 0}
 
 /** Create data item for int64_t variable. */
-#define TS_RECORD_ITEM_INT64(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_INT64(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT64, 0}
 
 /** Create data item for uint32_t variable. */
-#define TS_RECORD_ITEM_UINT32(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_UINT32(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_UINT32, 0}
 
 /** Create data item for int32_t variable. */
-#define TS_RECORD_ITEM_INT32(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_INT32(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT32, 0}
 
 /** Create data item for uint16_t variable. */
-#define TS_RECORD_ITEM_UINT16(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_UINT16(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_UINT16, 0}
 
 /** Create data item for int16_t variable. */
-#define TS_RECORD_ITEM_INT16(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_INT16(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT16, 0}
 
 /** Create data item for uint8_t variable. */
-#define TS_RECORD_ITEM_UINT8(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_UINT8(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_UINT8, 0}
 
 /** Create data item for int8_t variable. */
-#define TS_RECORD_ITEM_INT8(parent_id, id, name, struct_type, struct_member) \
+#define TS_RECORD_ITEM_INT8(id, name, struct_type, struct_member, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_INT8, 0}
 
 /** Create data item for float variable. */
-#define TS_RECORD_ITEM_FLOAT(parent_id, id, name, struct_type, struct_member, digits) \
+#define TS_RECORD_ITEM_FLOAT(id, name, struct_type, struct_member, digits, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_FLOAT32, digits}
 
 #ifdef __ZEPHYR__
@@ -418,6 +418,17 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_ADD_ITEM_ARRAY(id, ...)      _TS_ADD_ITERABLE(ITEM_ARRAY, id, __VA_ARGS__)
 #define TS_ADD_SUBSET(id, ...)          _TS_ADD_ITERABLE(SUBSET, id, __VA_ARGS__)
 #define TS_ADD_GROUP(id, ...)           _TS_ADD_ITERABLE(GROUP, id, __VA_ARGS__)
+#define TS_ADD_RECORDS(id, ...)         _TS_ADD_ITERABLE(RECORDS, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_BOOL(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_BOOL, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT64(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT64, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT64(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT64, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT32(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT32, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT32(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT32, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT16(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT16, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT16(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT16, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT8(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_UINT8, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT8(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_INT8, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_FLOAT(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_FLOAT, id, __VA_ARGS__)
 
 #endif /* __ZEPHYR__ */
 

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -372,6 +372,18 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_RECORD_ITEM_FLOAT(id, name, struct_type, struct_member, digits, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_FLOAT32, digits}
 
+/** Create data item for decimal fraction variable. */
+#define TS_RECORD_ITEM_DECFRAC(id, name, struct_type, struct_member, exponent, parent_id) \
+    {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_DECFRAC, exponent}
+
+/** Create data item for string variable. */
+#define TS_RECORD_ITEM_STRING(id, name, struct_type, struct_member, buf_size, parent_id) \
+    {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_STRING, buf_size}
+
+/** Create data item for bytes variable. */
+#define TS_RECORD_ITEM_BYTES(id, name, struct_type, struct_member, buf_size, parent_id) \
+    {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_BYTES, buf_size}
+
 #ifdef __ZEPHYR__
 
 /*
@@ -419,16 +431,19 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_ADD_SUBSET(id, ...)          _TS_ADD_ITERABLE(SUBSET, id, __VA_ARGS__)
 #define TS_ADD_GROUP(id, ...)           _TS_ADD_ITERABLE(GROUP, id, __VA_ARGS__)
 #define TS_ADD_RECORDS(id, ...)         _TS_ADD_ITERABLE(RECORDS, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_BOOL(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_BOOL, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_UINT64(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT64, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_INT64(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT64, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_UINT32(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT32, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_INT32(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT32, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_UINT16(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_UINT16, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_INT16(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_INT16, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_UINT8(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_UINT8, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_INT8(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_INT8, id, __VA_ARGS__)
-#define TS_ADD_RECORD_ITEM_FLOAT(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_FLOAT, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_BOOL(id, ...)    _TS_ADD_ITERABLE(RECORD_ITEM_BOOL, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT64(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_UINT64, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT64(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_INT64, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT32(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_UINT32, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT32(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_INT32, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT16(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_UINT16, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT16(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_INT16, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_UINT8(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_UINT8, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_INT8(id, ...)    _TS_ADD_ITERABLE(RECORD_ITEM_INT8, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_FLOAT(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_FLOAT, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_DECFRAC(id, ...) _TS_ADD_ITERABLE(RECORD_ITEM_DECFRAC, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_STRING(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_STRING, id, __VA_ARGS__)
+#define TS_ADD_RECORD_ITEM_BYTES(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_BYTES, id, __VA_ARGS__)
 
 #endif /* __ZEPHYR__ */
 

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -319,7 +319,7 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
     {id, parent_id, name, ts_array_to_void(array_info_ptr), TS_T_ARRAY, digits, access, subsets}
 
 /** Create a data object pointing to a struct ts_array. */
-#define TS_ITEM_RECORDS(id, name, records_ptr, parent_id, access, subsets) \
+#define TS_RECORDS(id, name, records_ptr, parent_id, access, subsets) \
     {id, parent_id, name, ts_records_to_void(records_ptr), TS_T_RECORDS, 0, access, subsets}
 
 /** Create a subset data object for the provided subset flag. */
@@ -481,6 +481,10 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_NODE_PATH(_id, _name, _parent, _callback) \
     TS_GROUP(_id, _name, _callback, _parent) \
     _Pragma ("GCC warning \"'TS_NODE_PATH' macro is deprecated, use 'TS_GROUP'\"")
+
+#define TS_ITEM_RECORDS(id, name, records_ptr, parent_id, access, subsets) \
+    TS_RECORDS(id, name, records_ptr, parent_id, access, subsets) \
+    _Pragma ("GCC warning \"'TS_ITEM_RECORDS' macro is deprecated, use 'TS_RECORDS'\"")
 
 /** @endcond */
 

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -174,7 +174,7 @@ struct ts_data_object data_objects[] = {
 
     // RECORDS used for logs //////////////////////////////////////////////////
 
-    TS_ITEM_RECORDS(0x7005, "Log", &records, ID_ROOT, TS_ANY_R, 0),
+    TS_RECORDS(0x7005, "Log", &records, ID_ROOT, TS_ANY_R, 0),
 
     /*
     * Record items definition.

--- a/test/test_data.c
+++ b/test/test_data.c
@@ -185,9 +185,9 @@ struct ts_data_object data_objects[] = {
     *
     * Important: All elements *must* be from the same struct.
     */
-    TS_RECORD_ITEM_UINT32(0x7005, 0x81, "t_s", struct test_struct, timestamp),
-    TS_RECORD_ITEM_FLOAT(0x7005, 0x82, "rBat_V", struct test_struct, battery_voltage, 2),
-    TS_RECORD_ITEM_UINT16(0x7005, 0x83, "sErrorFlags", struct test_struct, error_flags),
+    TS_RECORD_ITEM_UINT32(0x81, "t_s", struct test_struct, timestamp, 0x7005),
+    TS_RECORD_ITEM_FLOAT(0x82, "rBat_V", struct test_struct, battery_voltage, 2, 0x7005),
+    TS_RECORD_ITEM_UINT16(0x83, "sErrorFlags", struct test_struct, error_flags, 0x7005),
 
     // REPORTS ////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The macros for iterable records and record items were still missing.

Unfortunately, for Zephyr iterables to work, the first item has to be a unique ID, so we need to change the order of the existing `TS_RECORD_ITEM_*` macros.

The order was changed such that the compiler won't compile code with the old order, so that the breaking change is obvious. However, a breaking change cannot be avoided.

Advantage: The order is now more aligned with existing macros, where the unique ID is first and the parent ID is behind the pointer or the detail field.