### PR TITLE
Zephyr: Full support for iterable sections via Kconfig

### DIFF
--- a/src/thingset.c
+++ b/src/thingset.c
@@ -35,6 +35,30 @@ int ts_init(struct ts_context *ts, struct ts_data_object *data, size_t num)
     return 0;
 }
 
+#ifdef CONFIG_THINGSET_ITERABLE_SECTIONS
+
+/*
+ * ThingSet data objects are generated in each module using Zephyr's iterable section feature.
+ *
+ * Below pointers are normally used in the STRUCT_SECTION_FOREACH macro, but we want to use
+ * a pointer to the array of data objects directly, so we extract the memory locations manually.
+ */
+extern struct ts_data_object _ts_data_object_list_start[];
+extern struct ts_data_object _ts_data_object_list_end[];
+
+int ts_init_global(struct ts_context *ts)
+{
+    /* duplicates are checked at compile-time */
+
+    ts->data_objects = _ts_data_object_list_start;
+    ts->num_objects = _ts_data_object_list_end - _ts_data_object_list_start;
+    ts->_auth_flags = TS_USR_MASK;
+
+    return 0;
+}
+
+#endif
+
 int ts_process(struct ts_context *ts, const uint8_t *request, size_t request_len,
                uint8_t *response, size_t response_size)
 {

--- a/src/thingset.h
+++ b/src/thingset.h
@@ -384,8 +384,7 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_RECORD_ITEM_BYTES(id, name, struct_type, struct_member, buf_size, parent_id) \
     {id, parent_id, name, (void *)offsetof(struct_type, struct_member), TS_T_BYTES, buf_size}
 
-#ifdef __ZEPHYR__
-
+#ifdef CONFIG_THINGSET_ITERABLE_SECTIONS
 /*
  * Below macros can be used to populate the data objects array from multiple independent files
  * using the iterable sections feature provided by Zephyr.
@@ -445,7 +444,7 @@ static inline void *ts_records_to_void(struct ts_records *ptr) { return (void *)
 #define TS_ADD_RECORD_ITEM_STRING(id, ...)  _TS_ADD_ITERABLE(RECORD_ITEM_STRING, id, __VA_ARGS__)
 #define TS_ADD_RECORD_ITEM_BYTES(id, ...)   _TS_ADD_ITERABLE(RECORD_ITEM_BYTES, id, __VA_ARGS__)
 
-#endif /* __ZEPHYR__ */
+#endif /* CONFIG_THINGSET_ITERABLE_SECTIONS */
 
 /** @cond INTERNAL_HIDDEN */
 /*
@@ -707,6 +706,20 @@ struct ts_context {
  * @param num Number of elements in that array
  */
 int ts_init(struct ts_context *ts, struct ts_data_object *data, size_t num);
+
+#ifdef CONFIG_THINGSET_ITERABLE_SECTIONS
+
+/**
+ * Initialize a ThingSet context using Zephyr iterable sections.
+ *
+ * Data objects defined using TS_ADD_* macros will be magically added to the object database by the
+ * linker.
+ *
+ * @param ts Pointer to ThingSet context.
+ */
+int ts_init_global(struct ts_context *ts);
+
+#endif /* CONFIG_THINGSET_ITERABLE_SECTIONS */
 
 /**
  * Process ThingSet request.

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -19,6 +19,11 @@ zephyr_library_named("ts")
 
 zephyr_include_directories(${THINGSET_BASE}/src)
 
+if(DEFINED CONFIG_THINGSET_ITERABLE_SECTIONS)
+    # required for auto-generation of ts_data_objects array
+    zephyr_linker_sources(DATA_SECTIONS thingset_iterables.ld)
+endif()
+
 add_subdirectory(${THINGSET_BASE}/src build/thingset)
 
 if(DEFINED CONFIG_MINIMAL_LIBC)

--- a/zephyr/Kconfig.thingset
+++ b/zephyr/Kconfig.thingset
@@ -14,6 +14,15 @@ config THINGSET_ZEPHYR
         help
           ThingSet on Zephyr.
 
+config THINGSET_ITERABLE_SECTIONS
+        bool "Use iterable sections to define data objects globally"
+        default y
+        help
+          This option allows to define data objects where they are needed throughout the code
+          using the TS_ADD_* macros.
+
+          If enabled, the ThingSet context should be initialized with ts_init_global.
+
 config THINGSET_NUM_JSON_TOKENS
         int "Maximum number of expected JSON tokens."
         default 50

--- a/zephyr/thingset_iterables.ld
+++ b/zephyr/thingset_iterables.ld
@@ -1,0 +1,1 @@
+ITERABLE_SECTION_RAM(ts_data_object, 4)


### PR DESCRIPTION
Macros for Zephyr iterable sections feature was already implemented before.

This commit adds full support for iterable sections including the CMake part, so that the data objects can be initialized directly with the new `ts_init_global()` function. In addition to that, iterable sections support can be enabled via Kconfig (set to yes by default).